### PR TITLE
Only initialize once on multiuser devices

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,6 +10,8 @@
 
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
 
     <application android:persistent="true" android:directBootAware="true" >
         <service android:name=".QcRilAmService" />

--- a/src/me/phh/qcrilam/BootReceiver.kt
+++ b/src/me/phh/qcrilam/BootReceiver.kt
@@ -23,9 +23,12 @@ package me.phh.qcrilam
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.UserManager
 
 class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
-        context.startService(Intent(context, QcRilAmService::class.java))
+        if (UserManager.get(context).isSystemUser()){
+            context.startService(Intent(context, QcRilAmService::class.java))
+        }
     }
 }


### PR DESCRIPTION
On devices with multiple users (or work profiles), the boot receiver is called for each user. But if the most recently signed-in user logs out (or if work profile is turned off), the incall audio callback are not dead (invalid), therefore incall audio will stop working.

To solve this, only initialize on the main system user.